### PR TITLE
[Modify]還沒Scroll前Navbar為透明底，Scroll後會加上底色與陰影

### DIFF
--- a/src/components/Navbar-component.js
+++ b/src/components/Navbar-component.js
@@ -3,17 +3,18 @@ import { Link } from "react-router-dom";
 
 const NavbarComponent = () => {
   const menuCollapseRef = useRef("");
-  const [navColor, setNavColor] = useState("");
+  // 如果 Scroll Y 軸 > 5 為 true；反之則為 false
+	const [isScrolled, setIsScrolled] = useState(false);
   const [navShadow, setNavShadow] = useState("");
 
   const listenScrollEvent = () => {
     if (window.scrollY > 5) {
-      setNavColor("lg:bg-sky-800");
-      setNavShadow("shadow-xl");
-    } else {
-      setNavColor("");
-      setNavShadow("");
-    }
+			setIsScrolled(true);
+			setNavShadow('shadow-xl');
+		} else {
+			setIsScrolled(false);
+			setNavShadow('');
+		}
   };
 
   const menuHandler = () => {
@@ -26,12 +27,12 @@ const NavbarComponent = () => {
 
   useEffect(() => {
     window.addEventListener("scroll", listenScrollEvent);
-  }, [navColor]);
+  }, [isScrolled]);
 
   return (
     <div>
       <nav
-        className={`navbar duration-400 fixed top-0 z-50 w-full transition ease-in-out ${navShadow} ${navColor} select-none justify-center bg-sky-800 lg:flex lg:items-stretch lg:bg-transparent`}
+        className={`navbar duration-400 fixed top-0 z-50 w-full transition ease-in-out ${navShadow} ${isScrolled ? 'lg:bg-sky-800' : 'lg:bg-transparent'} select-none justify-center bg-sky-800 lg:flex lg:items-stretch`}
       >
         <div className=" mx-9 flex h-12 text-3xl text-black ">
           <button


### PR DESCRIPTION
你原本的程式碼出錯，主要原因在於：
transparent 的樣式沒有拿掉，所以就算底色有被改到，權重還是會被 transparent 覆蓋過去。

我這邊把樣式的 className 寫成 Boolean 判斷，但這個寫法會讓 className 變得很長。
建議你可以使用這個樣式框架的 Component 設定，比較不會讓 Code 看起來很凌亂。
https://tailwindcss.com/docs/adding-custom-styles#adding-component-classes

另外，你的檔案超大，要找一下原因，照理來說元件不多，不應該有這種情形。
再來就是字型建議轉成圖片，下載你的專案時間比下載我公司專案的時間還長 XD

以上是我的建議，有任何不懂都可以再問，我有時間會盡量抽空回答你。
